### PR TITLE
making responsive, no need for forcing repaints

### DIFF
--- a/assets/style/main.css
+++ b/assets/style/main.css
@@ -2,6 +2,7 @@ html, body {
     height: 100%;
 
     font-family: sans-serif;
+    overflow:hidden;
 }
 
 body {
@@ -17,13 +18,21 @@ body {
     height: 90%;;
     display: flex;
     flex-direction: column;
+    max-width: 900px;
+    margin: 0 auto;
 }
 
 h1 {
     margin: 0;
     text-align: center;
     font-size: 500%;
-    font-size: 15vh;
+    font-size: 24vw;
+}
+
+@media (min-width: 512px) {
+    h1 {
+      font-size: 15vh;
+    }
 }
 
 p {
@@ -58,11 +67,11 @@ h1 a {
     margin: 0;
 }
 
-.abscenter {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    -webkit-transform: translate(-50%, -50%);
-    -ms-transform: translate(-50%, -50%);
-    transform: translate(-50%, -50%);
-}
+/* .abscenter {                                  */
+/*     position: absolute;                       */
+/*     top: 50%;                                 */
+/*     left: 50%;                                */
+/*     -webkit-transform: translate(-50%, -50%); */
+/*     -ms-transform: translate(-50%, -50%);     */
+/*     transform: translate(-50%, -50%);         */
+/* }                                             */

--- a/index.html
+++ b/index.html
@@ -2,13 +2,15 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Assetgraph</title>
 
     <link rel="stylesheet" href="/assets/style/main.css">
 </head>
 <body>
 
-    <div class="page abscenter">
+    <!-- <div class="page abscenter"> -->
+    <div class="page">
         <h1><a href="https://github.com/assetgraph/"><span class="title-primary">ASSET</span><wbr><span class="title-secondary">GRAPH</span></a></h1>
 
         <p>Work like the web</p>
@@ -16,7 +18,7 @@
         <a href="https://github.com/assetgraph/" class="logo-splash"></a>
     </div>
 
-    <script type="text/javascript">
+    <!-- <script type="text/javascript">
 
         // Hack for updating viewport relative font sizes on resize
         window.onresize = function() {
@@ -28,7 +30,7 @@
                 });
             });
         }
-    </script>
+    </script> -->
 
 </body>
 </html>


### PR DESCRIPTION
Removed javascript hack - for resizing issue is fixed in Chrome 34+ and Safari 7+. Don't really need 'absolute centering' either, but is maybe not essential.
